### PR TITLE
Create statefulcheckpoint node during init

### DIFF
--- a/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
+++ b/heron/statemgrs/src/cpp/statemgr/heron-localfilestatemgr.cpp
@@ -55,6 +55,9 @@ void HeronLocalFileStateMgr::InitTree() {
   path = dpath;
   path += "/executionstate";
   FileUtils::makeDirectory(path);
+  path = dpath;
+  path += "statefulcheckpoint";
+  FileUtils::makeDirectory(path);
 }
 
 void HeronLocalFileStateMgr::SetTMasterLocationWatch(const std::string& topology_name,


### PR DESCRIPTION
Fixes the issue that local fs state manager will not create statfulcheckpoint node during init