### PR TITLE
Bugs fixing in localfs

### DIFF
--- a/heron/ckptmgr/src/cpp/common/checkpoint.cpp
+++ b/heron/ckptmgr/src/cpp/common/checkpoint.cpp
@@ -38,6 +38,7 @@ Checkpoint::Checkpoint(const std::string& _topology,
   ckptid_ = _checkpoint->checkpoint_id();
   component_ = _checkpoint->instance().info().component_name();
   instance_ = _checkpoint->instance().instance_id();
+  taskid_ = std::to_string(_checkpoint->instance().info().task_id());
   savebytes_ = nullptr;
   nbytes_ = 0;
 }

--- a/heron/ckptmgr/src/cpp/localfs/localfs.cpp
+++ b/heron/ckptmgr/src/cpp/localfs/localfs.cpp
@@ -80,10 +80,10 @@ int LocalFS::store(const Checkpoint& _ckpt) {
 
   // write the contents atomically to file
   size_t len = _ckpt.nbytes();
-  char* buf = new char[len];
-  _ckpt.checkpoint()->SerializeToArray(buf, len);
+  std::string buf;
+  _ckpt.checkpoint()->SerializeToString(&buf);
 
-  if (!FileUtils::writeAtomicAll(path, buf, len)) {
+  if (!FileUtils::writeAtomicAll(path, buf.c_str(), len)) {
     LOG(ERROR) << "Failed to checkpoint " << path << " for " << logMessageFragment(_ckpt);
     return SP_NOTOK;
   }

--- a/heron/ckptmgr/src/cpp/localfs/localfs.cpp
+++ b/heron/ckptmgr/src/cpp/localfs/localfs.cpp
@@ -73,7 +73,8 @@ int LocalFS::store(const Checkpoint& _ckpt) {
   std::string path = ckptFile(_ckpt);
   // create the checkpoint directory, if not there
   if (createCkptDirectory(_ckpt) == SP_NOTOK) {
-    LOG(ERROR) << "Failed to create dir " << " for " << logMessageFragment(_ckpt);
+    LOG(ERROR) << "Failed to create dir "
+      << ckptDirectory(_ckpt) << " for " << logMessageFragment(_ckpt);
     return SP_NOTOK;
   }
 

--- a/heron/ckptmgr/src/cpp/localfs/localfs.cpp
+++ b/heron/ckptmgr/src/cpp/localfs/localfs.cpp
@@ -70,18 +70,20 @@ int LocalFS::createCkptDirectory(const Checkpoint& _ckpt) {
 }
 
 int LocalFS::store(const Checkpoint& _ckpt) {
+  std::string path = ckptFile(_ckpt);
   // create the checkpoint directory, if not there
   if (createCkptDirectory(_ckpt) == SP_NOTOK) {
-    LOG(ERROR) << "Checkpoint failed for " << logMessageFragment(_ckpt);
+    LOG(ERROR) << "Failed to create dir " << " for " << logMessageFragment(_ckpt);
     return SP_NOTOK;
   }
 
   // write the contents atomically to file
   size_t len = _ckpt.nbytes();
-  char* buf = reinterpret_cast<char*>(_ckpt.checkpoint());
+  char* buf = new char[len];
+  _ckpt.checkpoint()->SerializeToArray(buf, len);
 
-  if (!FileUtils::writeAtomicAll(ckptFile(_ckpt), buf, len)) {
-    LOG(ERROR) << "Checkpoint failed for " << logMessageFragment(_ckpt);
+  if (!FileUtils::writeAtomicAll(path, buf, len)) {
+    LOG(ERROR) << "Failed to checkpoint " << path << " for " << logMessageFragment(_ckpt);
     return SP_NOTOK;
   }
 
@@ -89,20 +91,21 @@ int LocalFS::store(const Checkpoint& _ckpt) {
 }
 
 int LocalFS::restore(Checkpoint& _ckpt) {
-  std::string file = ckptFile(_ckpt);
+  std::string path = ckptFile(_ckpt);
 
   // open the checkpoint file
-  std::ifstream ifile(ckptFile(_ckpt), std::ifstream::in | std::ifstream::binary);
+  std::ifstream ifile(path, std::ifstream::in | std::ifstream::binary);
   if (!ifile.is_open()) {
-    PLOG(ERROR) << "Unable to open checkpoint file " << tempCkptFile(_ckpt);
-    LOG(ERROR) << "Restore checkpoint failed for " << logMessageFragment(_ckpt);
+    PLOG(ERROR) << "Failed to open checkpoint file " << path;
+    LOG(ERROR) << "Failed to restore checkpoint for " << logMessageFragment(_ckpt);
     return SP_NOTOK;
   }
 
   // read the protobuf from checkpoint file
   auto savedbytes = new ::heron::proto::ckptmgr::SaveInstanceStateRequest;
   if (!savedbytes->ParseFromIstream(&ifile)) {
-    LOG(ERROR) << "Restore checkpoint failed for " << logMessageFragment(_ckpt);
+    LOG(ERROR) << "Failed to restore checkpoint from " << path
+      << " for "<< logMessageFragment(_ckpt);
     return SP_NOTOK;
   }
 


### PR DESCRIPTION
1. Fixes the wrong way of SaveInstanceStateRequest serialization during store()
2. Fixes that taskid_ is not set during constructor of Checkpoint, which leads to wrong checkpoint-state path.
3. Improve the logging.