### PR TITLE
Add HDFS backend support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,16 +117,6 @@ maven_jar(
 )
 
 maven_jar(
-  name = "org_apache_hadoop_hadoop_common_2_6_1",
-  artifact = "org.apache.hadoop:hadoop-common:2.6.1",
-)
-
-maven_jar(
-  name = "org_apache_hadoop_hadoop_annotations_2_6_1",
-  artifact = "org.apache.hadoop:hadoop-annotations:2.6.1",
-)
-
-maven_jar(
   name = "org_apache_httpcomponents_http_client",
   artifact = "org.apache.httpcomponents:httpclient:4.5.2",
 )
@@ -345,14 +335,4 @@ maven_jar(
 maven_jar(
   name = "com_101tec_zkclient",
   artifact = "com.101tec:zkclient:0.3"
-)
-
-maven_jar(
-  name = "commons_configuration_commons_configuration_1_6",
-  artifact = "commons-configuration:commons-configuration:1.6",
-)
-
-maven_jar(
-  name = "org_apache_hadoop_hadoop_auth_2_6_1",
-  artifact = "org.apache.hadoop:hadoop-auth:2.6.1",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,6 +117,16 @@ maven_jar(
 )
 
 maven_jar(
+  name = "org_apache_hadoop_hadoop_common_2_6_0",
+  artifact = "org.apache.hadoop:hadoop-common:2.6.0",
+)
+
+maven_jar(
+  name = "org_apache_hadoop_hadoop_annotations_2_6_0",
+  artifact = "org.apache.hadoop:hadoop-annotations:2.6.0",
+)
+
+maven_jar(
   name = "org_apache_httpcomponents_http_client",
   artifact = "org.apache.httpcomponents:httpclient:4.5.2",
 )
@@ -335,4 +345,14 @@ maven_jar(
 maven_jar(
   name = "com_101tec_zkclient",
   artifact = "com.101tec:zkclient:0.3"
+)
+
+maven_jar(
+  name = "commons_configuration_commons_configuration_1_6",
+  artifact = "commons-configuration:commons-configuration:1.6",
+)
+
+maven_jar(
+  name = "org_apache_hadoop_hadoop_auth_2_6_0",
+  artifact = "org.apache.hadoop:hadoop-auth:2.6.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,13 +117,13 @@ maven_jar(
 )
 
 maven_jar(
-  name = "org_apache_hadoop_hadoop_common_2_6_0",
-  artifact = "org.apache.hadoop:hadoop-common:2.6.0",
+  name = "org_apache_hadoop_hadoop_common_2_6_1",
+  artifact = "org.apache.hadoop:hadoop-common:2.6.1",
 )
 
 maven_jar(
-  name = "org_apache_hadoop_hadoop_annotations_2_6_0",
-  artifact = "org.apache.hadoop:hadoop-annotations:2.6.0",
+  name = "org_apache_hadoop_hadoop_annotations_2_6_1",
+  artifact = "org.apache.hadoop:hadoop-annotations:2.6.1",
 )
 
 maven_jar(
@@ -353,6 +353,6 @@ maven_jar(
 )
 
 maven_jar(
-  name = "org_apache_hadoop_hadoop_auth_2_6_0",
-  artifact = "org.apache.hadoop:hadoop-auth:2.6.0",
+  name = "org_apache_hadoop_hadoop_auth_2_6_1",
+  artifact = "org.apache.hadoop:hadoop-auth:2.6.1",
 )

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -2,6 +2,8 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+load("/tools/rules/jarjar_rules", "jarjar_binary")
+
 java_library(
     name = "ckptmgr-java",
     srcs = glob(
@@ -39,9 +41,17 @@ java_binary(
     ],
 )
 
-genrule(
+jarjar_binary(
     name = "heron-ckptmgr",
-    srcs = [":ckptmgr-unshaded_deploy.jar"],
-    outs = ["heron-ckptmgr.jar"],
-    cmd  = "cp $< $@",
+    src = ":ckptmgr-unshaded_deploy.jar",
+    shade = "shade.conf",
+    deps = ["@org_sonatype_plugins_jarjar_maven_plugin//jar"]
 )
+
+#genrule(
+#    name = "heron-ckptmgr",
+#    srcs = [":ckptmgr-unshaded_deploy.jar"],
+#    outs = ["heron-ckptmgr.jar"],
+#    cmd  = "cp $< $@",
+#)
+#

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -15,15 +15,16 @@ java_library(
         "//heron/proto:proto_ckptmgr_java",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
-        # for hdfs-state-backend, these jars should be attached in runtime
-        "@org_apache_hadoop_hadoop_common_2_6_1//jar",
-        "@org_apache_hadoop_hadoop_annotations_2_6_1//jar",
-        "@commons_logging_commons_logging//jar",
-        "@commons_collections_commons_collections//jar",
-        "@commons_lang_commons_lang//jar",
-        "@commons_configuration_commons_configuration_1_6//jar",
-        "@org_apache_hadoop_hadoop_auth_2_6_1//jar",
-        "//third_party/java:logging",
+        "//third_party/java:hadoop-core",
+#        # for hdfs-state-backend, these jars should be attached in runtime
+#        "@org_apache_hadoop_hadoop_common_2_6_1//jar",
+#        "@org_apache_hadoop_hadoop_annotations_2_6_1//jar",
+#        "@commons_logging_commons_logging//jar",
+#        "@commons_collections_commons_collections//jar",
+#        "@commons_lang_commons_lang//jar",
+#        "@commons_configuration_commons_configuration_1_6//jar",
+#        "@org_apache_hadoop_hadoop_auth_2_6_1//jar",
+#        "//third_party/java:logging",
     ],
 )
 

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -13,10 +13,11 @@ java_library(
         "//heron/common/src/java:common-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_ckptmgr_java",
-        # for hdfs-state-backend, the jar should be attached in runtime
-        "@org_apache_hadoop_hadoop_core//jar",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
+        # for hdfs-state-backend, the jar should be attached in runtime
+        "@org_apache_hadoop_hadoop_core//jar",
+        "@commons_logging_commons_logging//jar",
     ],
 )
 

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -13,6 +13,7 @@ java_library(
         "//heron/common/src/java:common-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_ckptmgr_java",
+        "//third_party/java:hadoop-core",  # for hdfs-state-backend
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
     ],

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -17,16 +17,7 @@ java_library(
         "//heron/proto:proto_ckptmgr_java",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
-        "//third_party/java:hadoop-core",
-#        # for hdfs-state-backend, these jars should be attached in runtime
-#        "@org_apache_hadoop_hadoop_common_2_6_1//jar",
-#        "@org_apache_hadoop_hadoop_annotations_2_6_1//jar",
-#        "@commons_logging_commons_logging//jar",
-#        "@commons_collections_commons_collections//jar",
-#        "@commons_lang_commons_lang//jar",
-#        "@commons_configuration_commons_configuration_1_6//jar",
-#        "@org_apache_hadoop_hadoop_auth_2_6_1//jar",
-#        "//third_party/java:logging",
+        "//third_party/java:hadoop-core",  # for hdfs-state-backend
     ],
 )
 
@@ -47,11 +38,3 @@ jarjar_binary(
     shade = "shade.conf",
     deps = ["@org_sonatype_plugins_jarjar_maven_plugin//jar"]
 )
-
-#genrule(
-#    name = "heron-ckptmgr",
-#    srcs = [":ckptmgr-unshaded_deploy.jar"],
-#    outs = ["heron-ckptmgr.jar"],
-#    cmd  = "cp $< $@",
-#)
-#

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -13,7 +13,8 @@ java_library(
         "//heron/common/src/java:common-java",
         "//heron/proto:proto_common_java",
         "//heron/proto:proto_ckptmgr_java",
-        "//third_party/java:hadoop-core",  # for hdfs-state-backend
+        # for hdfs-state-backend, the jar should be attached in runtime
+        "@org_apache_hadoop_hadoop_core//jar",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
     ],

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -15,9 +15,15 @@ java_library(
         "//heron/proto:proto_ckptmgr_java",
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
-        # for hdfs-state-backend, the jar should be attached in runtime
-        "@org_apache_hadoop_hadoop_core//jar",
+        # for hdfs-state-backend, these jars should be attached in runtime
+        "@org_apache_hadoop_hadoop_common_2_6_0//jar",
+        "@org_apache_hadoop_hadoop_annotations_2_6_0//jar",
         "@commons_logging_commons_logging//jar",
+        "@commons_collections_commons_collections//jar",
+        "@commons_lang_commons_lang//jar",
+        "@commons_configuration_commons_configuration_1_6//jar",
+        "@org_apache_hadoop_hadoop_auth_2_6_0//jar",
+        "//third_party/java:logging",
     ],
 )
 

--- a/heron/ckptmgr/src/java/BUILD
+++ b/heron/ckptmgr/src/java/BUILD
@@ -16,13 +16,13 @@ java_library(
         "@com_google_protobuf_protobuf_java//jar",
         "@org_yaml_snakeyaml//jar",
         # for hdfs-state-backend, these jars should be attached in runtime
-        "@org_apache_hadoop_hadoop_common_2_6_0//jar",
-        "@org_apache_hadoop_hadoop_annotations_2_6_0//jar",
+        "@org_apache_hadoop_hadoop_common_2_6_1//jar",
+        "@org_apache_hadoop_hadoop_annotations_2_6_1//jar",
         "@commons_logging_commons_logging//jar",
         "@commons_collections_commons_collections//jar",
         "@commons_lang_commons_lang//jar",
         "@commons_configuration_commons_configuration_1_6//jar",
-        "@org_apache_hadoop_hadoop_auth_2_6_0//jar",
+        "@org_apache_hadoop_hadoop_auth_2_6_1//jar",
         "//third_party/java:logging",
     ],
 )

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManager.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManager.java
@@ -87,7 +87,6 @@ public class CheckpointManager {
   }
 
   public static void main(String[] args) throws IOException {
-    System.out.println("Hello World!");
     if (args.length != 9) {
       throw new RuntimeException(
           "Invalid arguments; Usage: java com.twitter.heron.ckptmgr.CheckpointManager "

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerConfig.java
@@ -27,6 +27,7 @@ import com.twitter.heron.common.basics.SysUtils;
 public class CheckpointManagerConfig {
   public static final String CONFIG_KEY_STATEFUL_BACKEND = "stateful-backend";
   public static final String CONFIG_KEY_CLASSNAME = "class";
+  public static final String CONFIG_KEY_CLASSPATH = "classpath";
 
   private final Map<String, Object> backendConfig = new HashMap<>();
 

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerServer.java
@@ -181,23 +181,25 @@ public class CheckpointManagerServer extends HeronServer {
               .setCheckpointId(request.getCheckpointId())
               .setState(ByteString.EMPTY).build();
 
-
       responseBuilder.setCheckpoint(dummyState);
     } else {
       boolean res = checkpointsBackend.restore(checkpoint);
-      statusCode = res ? Common.StatusCode.OK : Common.StatusCode.NOTOK;
+      if (res) {
+        LOG.info("Get checkpoint successful for " + checkpoint.getCheckpointId() + " "
+            + checkpoint.getComponent() + " " + checkpoint.getInstance());
 
-      responseBuilder.setCheckpoint(checkpoint.checkpoint().getCheckpoint());
+        // Set the checkpoint-state in response
+        responseBuilder.setCheckpoint(checkpoint.checkpoint().getCheckpoint());
+      } else {
+        LOG.info("Get checkpoint not successful for " + checkpoint.getCheckpointId() + " "
+            + checkpoint.getComponent() + " " + checkpoint.getInstance());
+      }
+
+      statusCode = res ? Common.StatusCode.OK : Common.StatusCode.NOTOK;
     }
 
     responseBuilder.setStatus(Common.Status.newBuilder().setStatus(statusCode));
-    if (statusCode.equals(Common.StatusCode.OK)) {
-      LOG.info("Get checkpoint successful for " + checkpoint.getCheckpointId() + " "
-          + checkpoint.getComponent() + " " + checkpoint.getInstance());
-    } else {
-      LOG.info("Get checkpoint not successful for " + checkpoint.getCheckpointId() + " "
-          + checkpoint.getComponent() + " " + checkpoint.getInstance());
-    }
+
 
     sendResponse(rid, channel, responseBuilder.build());
   }

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerServer.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/CheckpointManagerServer.java
@@ -172,10 +172,11 @@ public class CheckpointManagerServer extends HeronServer {
     responseBuilder.setInstance(request.getInstance());
     responseBuilder.setCheckpointId(request.getCheckpointId());
 
-    Common.StatusCode statusCode = Common.StatusCode.NOTOK;
+    boolean res;
     if (!request.hasCheckpointId() || request.getCheckpointId().isEmpty()) {
+      res = true;
+
       LOG.info("The checkpoint id was empty, this sending empty state");
-      statusCode = Common.StatusCode.OK;
       CheckpointManager.InstanceStateCheckpoint dummyState =
           CheckpointManager.InstanceStateCheckpoint.newBuilder()
               .setCheckpointId(request.getCheckpointId())
@@ -183,7 +184,8 @@ public class CheckpointManagerServer extends HeronServer {
 
       responseBuilder.setCheckpoint(dummyState);
     } else {
-      boolean res = checkpointsBackend.restore(checkpoint);
+      res = checkpointsBackend.restore(checkpoint);
+
       if (res) {
         LOG.info("Get checkpoint successful for " + checkpoint.getCheckpointId() + " "
             + checkpoint.getComponent() + " " + checkpoint.getInstance());
@@ -194,12 +196,10 @@ public class CheckpointManagerServer extends HeronServer {
         LOG.info("Get checkpoint not successful for " + checkpoint.getCheckpointId() + " "
             + checkpoint.getComponent() + " " + checkpoint.getInstance());
       }
-
-      statusCode = res ? Common.StatusCode.OK : Common.StatusCode.NOTOK;
     }
 
+    Common.StatusCode statusCode = res ? Common.StatusCode.OK : Common.StatusCode.NOTOK;
     responseBuilder.setStatus(Common.Status.newBuilder().setStatus(statusCode));
-
 
     sendResponse(rid, channel, responseBuilder.build());
   }

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -68,6 +69,22 @@ public class HdfsBackend implements IBackend {
       LOG.severe("Failed to ensure root path: " + checkpointRootPath);
     }
 
+    // List
+    try {
+      for (FileStatus fs : fileSystem.listStatus(new Path("/user/mfu"))) {
+        LOG.info(fs.getPath().toString());
+      }
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to ls the path: " + "/user/mfu", e);
+    }
+
+    try {
+      boolean res = fileSystem.exists(new Path("/user/mfu/test.yaml"));
+      LOG.info("exists? " + res);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to exists /user/mfu/test.yaml", e);
+    }
+
 
     Path path = new Path("/user/mfu/test-data");
 
@@ -80,7 +97,7 @@ public class HdfsBackend implements IBackend {
       out.flush();
       out.close();
     } catch (IOException e) {
-      LOG.log(Level.SEVERE, "Failed to write: ", e);
+      LOG.log(Level.SEVERE, "Failed to write to path: " + path, e);
     }
 
     // Try to read something
@@ -90,8 +107,20 @@ public class HdfsBackend implements IBackend {
       in.readFully(b);
       String s = new String(b);
       LOG.info(s);
+      in.close();
     } catch (IOException e) {
-      LOG.log(Level.SEVERE, "Failed to read: ", e);
+      LOG.log(Level.SEVERE, "Failed to read from path: " + path, e);
+    }
+
+    // Try to read something
+    try {
+      FSDataInputStream in = fileSystem.open(new Path("/user/mfu/test.yaml"));
+      byte[] b = new byte[content.getBytes().length];
+      in.readFully(b);
+      String s = new String(b);
+      LOG.info(s);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to read from path: /user/mfu/test.yaml", e);
     }
 
   }

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -61,6 +61,39 @@ public class HdfsBackend implements IBackend {
     } catch (IOException e) {
       throw new RuntimeException("Failed to get hadoop file system", e);
     }
+
+
+    // For test
+    if (!ensureDirExists(checkpointRootPath)) {
+      LOG.severe("Failed to ensure root path: " + checkpointRootPath);
+    }
+
+
+    Path path = new Path("/user/mfu/test-data");
+
+
+    // Trey to write something
+    String content = "WO cao ni ma bi";
+    try {
+      FSDataOutputStream out = fileSystem.create(path);
+      out.write(content.getBytes());
+      out.flush();
+      out.close();
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to write: ", e);
+    }
+
+    // Try to read something
+    try {
+      FSDataInputStream in = fileSystem.open(path);
+      byte[] b = new byte[content.getBytes().length];
+      in.readFully(b);
+      String s = new String(b);
+      LOG.info(s);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to read: ", e);
+    }
+
   }
 
   @Override

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -1,0 +1,147 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.twitter.heron.ckptmgr.backend.hdfs;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.twitter.heron.ckptmgr.backend.Checkpoint;
+import com.twitter.heron.ckptmgr.backend.IBackend;
+import com.twitter.heron.common.basics.SysUtils;
+import com.twitter.heron.proto.ckptmgr.CheckpointManager;
+
+public class HdfsBackend implements IBackend {
+  private static final Logger LOG = Logger.getLogger(HdfsBackend.class.getName());
+
+  private static final String ROOT_PATH_KEY = "root.path";
+  private static final String HDFS_CONFIG_DIR_KEY = "hdfs.config.dir";
+
+  // TODO(mfu): Also need to specify actual hadoop jar in config and append on classpath
+
+  private String checkpointRootPath;
+  private String hdfsConfigDir;
+
+  private FileSystem fileSystem;
+
+  @Override
+  public void init(Map<String, Object> conf) {
+    LOG.info("Initialing... Config: " + conf.toString());
+
+    hdfsConfigDir = (String) conf.get(HDFS_CONFIG_DIR_KEY);
+    checkpointRootPath = (String) conf.get(ROOT_PATH_KEY);
+
+    // TODO(mfu): Make it work with passing the config folder from classpath
+    Configuration hadoopConfig = new Configuration();
+    hadoopConfig.addResource(new Path(hdfsConfigDir + "core-site.xml"));
+    hadoopConfig.addResource(new Path(hdfsConfigDir + "hdfs-site.xml"));
+    hadoopConfig.addResource(new Path(hdfsConfigDir + "mapred-site.xml"));
+
+    try {
+      fileSystem = FileSystem.get(hadoopConfig);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to get hadoop file system", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    SysUtils.closeIgnoringExceptions(fileSystem);
+  }
+
+  @Override
+  public boolean store(Checkpoint checkpoint) {
+    Path path = new Path(getCheckpointPath(checkpoint));
+
+    if (!ensureDirExists(getCheckpointDir(checkpoint))) {
+      LOG.warning("Failed to ensure dir exists: " + getCheckpointDir(checkpoint));
+      return false;
+    }
+
+    FSDataOutputStream out = null;
+    try {
+      out = fileSystem.create(path);
+      checkpoint.checkpoint().writeTo(out);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to persist", e);
+      return false;
+    } finally {
+      SysUtils.closeIgnoringExceptions(out);
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean restore(Checkpoint checkpoint) {
+    Path path = new Path(getCheckpointPath(checkpoint));
+
+    FSDataInputStream in = null;
+    CheckpointManager.SaveInstanceStateRequest state = null;
+    try {
+      in = fileSystem.open(path);
+      state =
+          CheckpointManager.SaveInstanceStateRequest.parseFrom(in);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to read", e);
+      return false;
+    } finally {
+      SysUtils.closeIgnoringExceptions(in);
+    }
+
+    checkpoint.setCheckpoint(state);
+
+    return true;
+  }
+
+  protected boolean ensureDirExists(String dir) {
+    Path path = new Path(dir);
+
+    try {
+      fileSystem.mkdirs(path);
+      if (!fileSystem.exists(path)) {
+        return false;
+      }
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to mkdirs: " + dir, e);
+      return false;
+    }
+
+    return true;
+  }
+
+  protected String getCheckpointDir(Checkpoint checkpoint) {
+    return new StringBuilder()
+        .append(checkpointRootPath).append("/")
+        .append(checkpoint.getCheckpointId()).append("/")
+        .append(checkpoint.getComponent())
+        .toString();
+
+  }
+
+  protected String getCheckpointPath(Checkpoint checkpoint) {
+    return new StringBuilder()
+        .append(getCheckpointDir(checkpoint)).append("/")
+        .append(checkpoint.getTaskId())
+        .toString();
+  }
+}

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -53,9 +53,11 @@ public class HdfsBackend implements IBackend {
 
     // TODO(mfu): Make it work with passing the config folder from classpath
     Configuration hadoopConfig = new Configuration();
+    LOG.info("before. hadoop config: " + hadoopConfig.toString());
     hadoopConfig.addResource(new Path(hdfsConfigDir + "core-site.xml"));
     hadoopConfig.addResource(new Path(hdfsConfigDir + "hdfs-site.xml"));
     hadoopConfig.addResource(new Path(hdfsConfigDir + "mapred-site.xml"));
+    LOG.info("after. hadoop config: " + hadoopConfig.toString());
 
     try {
       fileSystem = FileSystem.get(hadoopConfig);

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -59,6 +59,8 @@ public class HdfsBackend implements IBackend {
 
     try {
       fileSystem = FileSystem.get(hadoopConfig);
+      LOG.info("URI: " + fileSystem.getUri());
+      LOG.info("Home dir: " + fileSystem.getHomeDirectory());
     } catch (IOException e) {
       throw new RuntimeException("Failed to get hadoop file system", e);
     }

--- a/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
+++ b/heron/ckptmgr/src/java/com/twitter/heron/ckptmgr/backend/hdfs/HdfsBackend.java
@@ -15,6 +15,8 @@
 package com.twitter.heron.ckptmgr.backend.hdfs;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,6 +65,18 @@ public class HdfsBackend implements IBackend {
     } catch (IOException e) {
       throw new RuntimeException("Failed to get hadoop file system", e);
     }
+
+    LOG.info("Class path:");
+    //Get the System Classloader
+    ClassLoader sysClassLoader = ClassLoader.getSystemClassLoader();
+
+    //Get the URLs
+    URL[] urls = ((URLClassLoader) sysClassLoader).getURLs();
+
+    for (int i = 0; i < urls.length; i++) {
+      LOG.info(urls[i].getFile());
+    }
+    LOG.info("class path ----end---");
   }
 
   @Override

--- a/heron/ckptmgr/src/java/shade.conf
+++ b/heron/ckptmgr/src/java/shade.conf
@@ -1,0 +1,3 @@
+rule com.google.protobuf** com.twitter.heron.shaded.@0
+rule org.yaml.snakeyaml** com.twitter.heron.shaded.@0
+

--- a/heron/config/src/yaml/conf/aurora/stateful.yaml
+++ b/heron/config/src/yaml/conf/aurora/stateful.yaml
@@ -3,6 +3,6 @@ stateful-backend:    hdfs-backend
 
 hdfs-backend:
   class: "com.twitter.heron.ckptmgr.backend.hdfs.HdfsBackend"
-  root.path:     "/user/mfu/"
+  root.path:     "/user/mfu/checkpoints"
   hdfs.config.dir: "/hadoop/config/folder"
   hadoop.classpath: ""

--- a/heron/config/src/yaml/conf/aurora/stateful.yaml
+++ b/heron/config/src/yaml/conf/aurora/stateful.yaml
@@ -1,0 +1,8 @@
+# indicate the type of storage for checkpoint is local file system
+stateful-backend:    hdfs-backend
+
+hdfs-backend:
+  class: "com.twitter.heron.ckptmgr.backend.hdfs.HdfsBackend"
+  root.path:     "/user/mfu/"
+  hdfs.config.dir: "/hadoop/config/folder"
+  hadoop.classpath: ""

--- a/heron/config/src/yaml/conf/aurora/stateful.yaml
+++ b/heron/config/src/yaml/conf/aurora/stateful.yaml
@@ -1,8 +1,7 @@
-# indicate the type of storage for checkpoint is local file system
+# indicate the type of storage for checkpoint is hdfs
 stateful-backend:    hdfs-backend
 
 hdfs-backend:
-  class: "com.twitter.heron.ckptmgr.backend.hdfs.HdfsBackend"
-  root.path:     "/user/mfu/checkpoints"
-  hdfs.config.dir: "/hadoop/config/folder"
-  hadoop.classpath: ""
+  class:             "com.twitter.heron.ckptmgr.backend.hdfs.HdfsBackend"
+  classpath:         "$(hadoop --config /path/to/configs classpath)"
+  root.path:         "/user/heron/checkpoints"

--- a/heron/config/src/yaml/conf/local/stateful.yaml
+++ b/heron/config/src/yaml/conf/local/stateful.yaml
@@ -2,5 +2,6 @@
 stateful-backend:    local-fs-backend
 
 local-fs-backend:
-  class: "com.twitter.heron.ckptmgr.backend.localfs.LocalFS"
-  root.path:     ./checkpoints
+  class:             "com.twitter.heron.ckptmgr.backend.localfs.LocalFS"
+  classpath:         ""
+  root.path:         "./checkpoints"

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/utils/SchedulerUtils.java
@@ -237,7 +237,12 @@ public final class SchedulerUtils {
     commands.add(schedulerPort);
     commands.add(Context.pythonInstanceSandboxBinary(config));
     commands.add(Boolean.toString(Context.isStateful(config)));
-    commands.add(Context.ckptmgrSandboxClassPath(config));
+
+    String completeCkptmgrProcessClasspath = new StringBuilder()
+        .append(Context.ckptmgrSandboxClassPath(config)).append(":")
+        .append(Context.stateBackendSandboxClassPath(config))
+        .toString();
+    commands.add(completeCkptmgrProcessClasspath);
     commands.add(ckptmgrPort);
     commands.add(Context.statefulConfigSandboxFile(config));
 

--- a/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
+++ b/heron/schedulers/src/java/com/twitter/heron/scheduler/aurora/AuroraScheduler.java
@@ -226,7 +226,12 @@ public class AuroraScheduler implements IScheduler, IScalable {
     auroraProperties.put("TOPOLOGY_PACKAGE_URI", topologyPkgURI);
 
     auroraProperties.put("IS_STATEFUL", Boolean.toString(Context.isStateful(config)));
-    auroraProperties.put("SANDBOX_CKPTMGR_CLASSPATH", Context.ckptmgrSandboxClassPath(config));
+
+    String completeCkptmgrProcessClasspath = new StringBuilder()
+        .append(Context.ckptmgrSandboxClassPath(config)).append(":")
+        .append(Context.stateBackendSandboxClassPath(config))
+        .toString();
+    auroraProperties.put("SANDBOX_CKPTMGR_CLASSPATH", completeCkptmgrProcessClasspath);
     auroraProperties.put("SANDBOX_STATEFUL_YAML", Context.statefulConfigSandboxFile(config));
 
     return auroraProperties;

--- a/heron/spi/src/java/com/twitter/heron/spi/common/ClusterConfig.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/ClusterConfig.java
@@ -67,7 +67,9 @@ public final class ClusterConfig {
         .put(Keys.systemFile(),
             Misc.substitute(heronHome, configPath, Defaults.systemFile()))
         .put(Keys.uploaderFile(),
-            Misc.substitute(heronHome, configPath, Defaults.uploaderFile()));
+            Misc.substitute(heronHome, configPath, Defaults.uploaderFile()))
+        .put(Keys.statefulFile(),
+            Misc.substitute(heronHome, configPath, Defaults.statefulFile()));
     return cb.build();
   }
 
@@ -188,7 +190,8 @@ public final class ClusterConfig {
         .putAll(loadPackingConfig(Context.packingSandboxFile(sandboxConfig)))
         .putAll(loadSchedulerConfig(Context.schedulerSandboxFile(sandboxConfig)))
         .putAll(loadStateManagerConfig(Context.stateManagerSandboxFile(sandboxConfig)))
-        .putAll(loadUploaderConfig(Context.uploaderSandboxFile(sandboxConfig)));
+        .putAll(loadUploaderConfig(Context.uploaderSandboxFile(sandboxConfig)))
+        .putAll(loadStatefulConfig(Context.statefulConfigSandboxFile(sandboxConfig)));
 
     // Add the override config at the end to replace any exisiting configs
     cb.putAll(loadOverrideConfig(Context.overrideSandboxFile(sandboxConfig)));

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Context.java
@@ -14,6 +14,8 @@
 
 package com.twitter.heron.spi.common;
 
+import java.util.Map;
+
 import com.twitter.heron.common.basics.ByteAmount;
 import com.twitter.heron.common.basics.PackageType;
 
@@ -372,5 +374,13 @@ public class Context {
 
   public static final Boolean isCleanStateCheckpoints(Config cfg) {
     return cfg.getBooleanValue(Keys.IS_CLEAN_STATEFUL_CHECKPOINTS, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static final String stateBackendSandboxClassPath(Config config) {
+    String stateBackend = config.getStringValue(Keys.CHECKPOINT_MGR_STATEFUL_BACKEND_ID);
+    Map<String, Object> backendConfig = (Map<String, Object>) config.get(stateBackend);
+    Object o = backendConfig.get("classpath");
+    return o == null ? "" : (String) o;
   }
 }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Defaults.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Defaults.java
@@ -262,6 +262,10 @@ public class Defaults {
     return ConfigDefaults.get("SANDBOX_STATEFUL_YAML");
   }
 
+  public static String statefulFile() {
+    return ConfigDefaults.get("STATEFUL_YAML");
+  }
+
   public static String uploaderSandboxFile() {
     return ConfigDefaults.get("SANDBOX_UPLOADER_YAML");
   }

--- a/heron/spi/src/java/com/twitter/heron/spi/common/Keys.java
+++ b/heron/spi/src/java/com/twitter/heron/spi/common/Keys.java
@@ -18,6 +18,7 @@ public class Keys {
   public static final String SCHEDULER_PROPERTIES = "heron.scheduler.properties";
   public static final String SCHEDULER_COMMAND_LINE_PROPERTIES_OVERRIDE_OPTION = "P";
   public static final String IS_CLEAN_STATEFUL_CHECKPOINTS = "is.clean.stateful.checkpoints";
+  public static final String CHECKPOINT_MGR_STATEFUL_BACKEND_ID = "stateful-backend";
 
   protected Keys() {
   }

--- a/heron/stmgr/src/cpp/manager/stmgr.cpp
+++ b/heron/stmgr/src/cpp/manager/stmgr.cpp
@@ -266,7 +266,7 @@ void StMgr::CreateCheckpointMgrClient() {
   LOG(INFO) << "Creating CheckpointMgr Client at " << IpUtils::getHostName() << ":"
             << checkpoint_manager_port_ << std::endl;
   NetworkOptions client_options;
-  client_options.set_host(IpUtils::getHostName());
+  client_options.set_host("localhost");
   client_options.set_port(checkpoint_manager_port_);
   client_options.set_socket_family(PF_INET);
   client_options.set_max_packet_size(std::numeric_limits<sp_uint32>::max() - 1);

--- a/scripts/centos5/BUILD
+++ b/scripts/centos5/BUILD
@@ -250,7 +250,7 @@ filegroup(
 
 filegroup(
     name = "hckptmgr",
-    srcs = ["//heron/ckptmgr/src/cpp:heron-ckptmgr"],
+    srcs = ["//heron/ckptmgr/src/java:heron-ckptmgr"],
 )
 
 filegroup(


### PR DESCRIPTION
1. Add HDFS stateful backend support. Already tested in distributed env with hdfs. People need to provide the classpath in stateful.yaml file so ckptmgr could append it to classpath in runtime.
2. Fixes the NPE in CkptMgr when could not fetch checkpoint from stateful backend.
3. Fixes the bugs that stmgr could not connect to ckptmgr caused by failure to resolve the hostname.
4. Shade CkptMgr to avoid protobuf dependencies complicit with hadoop-common libraries.